### PR TITLE
Fix for comments that contain unicode

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+Version 0.9.7
+~~~~~~~~~~~~~
+* Improved handling for unicode strings.
+
 Version 0.9.6
 ~~~~~~~~~~~~~
 

--- a/continuity/__init__.py
+++ b/continuity/__init__.py
@@ -11,4 +11,4 @@
 
 __author__ = "Jonathan Zempel"
 __license__ = "BSD"
-__version__ = "0.9.6"
+__version__ = "0.9.7"

--- a/continuity/cli/commons.py
+++ b/continuity/cli/commons.py
@@ -9,9 +9,9 @@
     :license: BSD, see LICENSE for more details.
 """
 
-from .utils import confirm, prompt, render
+from .utils import confirm, prompt, puts, render, to_ascii
 from argparse import REMAINDER, SUPPRESS
-from clint.textui import colored, indent, puts, puts_err
+from clint.textui import colored, indent, puts_err
 from continuity.services.commons import ServiceException
 from continuity.services.git import GitException, GitService
 from continuity.services.github import (GitHubException,
@@ -654,7 +654,7 @@ class StartCommand(GitCommand):
 
         if self.namespace.force or branch == self.branch.name:
             name = prompt(MESSAGES["git_branch"])
-            ret_val = '-'.join(name.split())
+            ret_val = '-'.join(to_ascii(name).split())
             prefix = self.get_template("branch-prefix")
 
             if prefix and not ret_val.startswith(prefix):

--- a/continuity/cli/github.py
+++ b/continuity/cli/github.py
@@ -13,8 +13,8 @@ from .commons import (FinishCommand as BaseFinishCommand,
         GitHubCommand as BaseGitHubCommand,
         ReviewCommand as BaseReviewCommand, StartCommand as BaseStartCommand,
         TasksCommand as BaseTasksCommand)
-from .utils import less
-from clint.textui import colored, puts
+from .utils import less, puts
+from clint.textui import colored
 from continuity.services.github import Issue
 from continuity.services.utils import cached_property
 from StringIO import StringIO
@@ -133,7 +133,7 @@ class IssueCommand(GitHubCommand):
                 puts(colored.yellow("{0} ({1})".format(
                     comment.user.login, comment.created)))
                 puts()
-                puts(str(comment))
+                puts(comment)
 
 
 class IssuesCommand(GitHubCommand):

--- a/continuity/cli/jira.py
+++ b/continuity/cli/jira.py
@@ -12,8 +12,8 @@
 from .commons import (FinishCommand as BaseFinishCommand, GitCommand,
         ReviewCommand as BaseReviewCommand, StartCommand as BaseStartCommand,
         TasksCommand as BaseTasksCommand)
-from .utils import edit, less, prompt
-from clint.textui import colored, indent, puts
+from .utils import edit, less, prompt, puts
+from clint.textui import colored, indent
 from continuity.services.jira import Issue, JiraException, JiraService
 from continuity.services.utils import cached_property
 from StringIO import StringIO
@@ -247,7 +247,7 @@ class IssueCommand(JiraCommand):
                 puts(colored.yellow("{0} ({1})".format(
                     comment.author.name, comment.created)))
                 puts()
-                puts(str(comment))
+                puts(comment)
 
 
 class IssuesCommand(JiraCommand):

--- a/continuity/cli/pt.py
+++ b/continuity/cli/pt.py
@@ -12,8 +12,8 @@
 from .commons import (FinishCommand as BaseFinishCommand, GitCommand,
         ReviewCommand as BaseReviewCommand, StartCommand as BaseStartCommand,
         TasksCommand as BaseTasksCommand)
-from .utils import edit, less, prompt
-from clint.textui import colored, indent, puts
+from .utils import edit, less, prompt, puts
+from clint.textui import colored, indent
 from continuity.services.pt import PivotalTrackerService, Story
 from continuity.services.utils import cached_property
 from StringIO import StringIO
@@ -121,9 +121,9 @@ class BacklogCommand(PivotalTrackerCommand):
                         if member in story.owners:
                             initials.append(member.initials)
 
-                    name = "{0} ({1})".format(story.name, ', '.join(initials))
+                    name = u"{0} ({1})".format(story.name, ', '.join(initials))
 
-                message = "{0} {1}: {2}\n".format(id, type, name)
+                message = u"{0} {1}: {2}\n".format(id, type, name)
                 output.write(message)
 
         less(output)
@@ -212,7 +212,7 @@ class StartCommand(BaseStartCommand, PivotalTrackerCommand):
             if not self.namespace.ignore:
                 state = ','.join(self.states(True))
                 filter = "id:{0} owner:{1} state:{2} -estimate:-1".format(
-                    self.namespace.id, self.owner, state)
+                    self.namespace.id, self.owner.id, state)
 
                 if self.pt.get_story(self.project, filter):
                     ret_val = "{0}\nUse -i to ignore the state on stories assigned to you.".\
@@ -241,7 +241,7 @@ class StartCommand(BaseStartCommand, PivotalTrackerCommand):
         """Execute this start command.
         """
         if self.story:
-            puts("Story: {0}".format(self.story.name))
+            puts(u"Story: {0}".format(self.story.name))
 
             if not self.story.owners:
                 self.story = self.pt.set_story(self.project, self.story,
@@ -288,18 +288,18 @@ class StartCommand(BaseStartCommand, PivotalTrackerCommand):
         state = ','.join(self.states(self.namespace.ignore))
 
         if story_id and exclusive:
-            puts("Retrieving story #{0} from Pivotal Tracker for {1}...".
+            puts(u"Retrieving story #{0} from Pivotal Tracker for {1}...".
                 format(story_id, self.owner))
             filter = "id:{0} owner:{1} state:{2} -estimate:-1".format(
-                story_id, self.owner, state)
+                story_id, self.owner.id, state)
         elif story_id:
             puts("Retrieving story #{0} from Pivotal Tracker...".format(
                 story_id))
             filter = "id:{0} state:{1} -estimate:-1".format(story_id, state)
         elif exclusive:
-            puts("Retrieving next story from Pivotal Tracker for {0}...".
+            puts(u"Retrieving next story from Pivotal Tracker for {0}...".
                 format(self.owner))
-            filter = "owner:{0} state:{1} -estimate:-1".format(self.owner,
+            filter = "owner:{0} state:{1} -estimate:-1".format(self.owner.id,
                 state)
         else:
             filter = None
@@ -358,7 +358,7 @@ class StoryCommand(PivotalTrackerCommand):
             puts(colored.cyan(self.story.description))
 
         puts()
-        puts(colored.white("Requested by {0} on {1}".format(
+        puts(colored.white(u"Requested by {0} on {1}".format(
             self.story.requester,
             self.story.created.strftime("%d %b %Y, %I:%M%p"))))
         puts(colored.white(self.story.url))
@@ -368,7 +368,7 @@ class StoryCommand(PivotalTrackerCommand):
 
             for comment in comments:
                 puts()
-                puts(colored.yellow("{0} ({1})".format(comment.author,
+                puts(colored.yellow(u"{0} ({1})".format(comment.author,
                     comment.created)))
                 puts()
                 puts(comment.text)
@@ -396,6 +396,6 @@ class TasksCommand(BaseTasksCommand, PivotalTrackerCommand):
         """
         for task in self.tasks:
             checkmark = 'x' if task.is_checked else ' '
-            message = "[{0}] {1}. {2}".format(checkmark, task.number,
+            message = u"[{0}] {1}. {2}".format(checkmark, task.number,
                     task.description)
             puts(message)

--- a/continuity/cli/utils.py
+++ b/continuity/cli/utils.py
@@ -9,7 +9,7 @@
     :license: BSD, see LICENSE for more details.
 """
 
-from clint.textui import puts
+from clint.textui import puts as _puts
 from curses.ascii import ctrl, CR, EOT, ETX, isctrl, LF
 from getch.getch import getch
 from getpass import getpass
@@ -20,8 +20,9 @@ from pydoc import pipepager
 from shlex import split
 from StringIO import StringIO
 from subprocess import CalledProcessError, check_call
-from sys import exit
+from sys import exit, stdout
 from tempfile import NamedTemporaryFile
+from unicodedata import normalize
 
 
 def confirm(message, default=False):
@@ -84,7 +85,7 @@ def less(text):
     if isinstance(text, StringIO):
         text = text.getvalue()
 
-    pipepager(text, cmd="less -FRSX")
+    pipepager(to_ascii(text), cmd="less -FRSX")
 
 
 def prompt(message, default=None, characters=None, echo=True):
@@ -138,6 +139,16 @@ def prompt(message, default=None, characters=None, echo=True):
     return ret_val
 
 
+def puts(string='', newline=True, stream=stdout.write):
+    """Print the given string.
+
+    :param string: Default `''`. The string to print.
+    :param newline: Default `True`. Add a newline to the output.
+    :param stream: Default `stdout`. The stream to print to.
+    """
+    _puts(to_ascii(string), newline, stream)
+
+
 def render(template, **context):
     """Render the given template.
 
@@ -177,3 +188,14 @@ def render(template, **context):
         exit(message)
 
     return template.render(context)
+
+
+def to_ascii(string):
+    """Convert the given string to ASCII.
+
+    :param string: The string to convert.
+    """
+    if not isinstance(string, unicode):
+        string = unicode(string, "utf-8")
+
+    return normalize("NFKD", string).encode("ascii", "ignore")


### PR DESCRIPTION
For example, a comment like `com – ment` bonks on `$ git story -c` with the following traceback:

```
Traceback (most recent call last):
  File "<string>", line 16, in <module>
  File "/private/tmp/continuity-1DRzO2/continuity-0.9.6/build/continuity/out00-PYZ.pyz/continuity.cli", line 134, in main
  File "/private/tmp/continuity-1DRzO2/continuity-0.9.6/build/continuity/out00-PYZ.pyz/continuity.cli.commons", line 84, in __call__
  File "/private/tmp/continuity-1DRzO2/continuity-0.9.6/build/continuity/out00-PYZ.pyz/continuity.cli.pt", line 374, in execute
  File "build/bdist.macosx-10.9-intel/egg/clint/textui/core.py", line 58, in puts
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2013' in position 4: ordinal not in range(128)
```
