### PR TITLE
Fix KeyboardInterrupt on git-start

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Version 0.9.7
 ~~~~~~~~~~~~~
 * Fixed JIRA `issues --myissues` query.
 * Improved handling for unicode strings.
+* Update installation dependencies.
 
 Version 0.9.6
 ~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -15,12 +15,12 @@ from sys import argv
 import continuity
 
 install_requires = [
-    "clint == 0.3.7",
-    "GitPython == 0.3.2.RC1",
+    "clint == 0.4.1",
+    "GitPython == 0.3.2.1",
     "Jinja2 == 2.7.3",
     "py-getch == 0.0.1",
     "python-dateutil < 2.0",
-    "requests == 2.4.1",
+    "requests == 2.5.0",
     "Sphinx == 1.2.3"
 ]
 


### PR DESCRIPTION
```
⌘ git start
Retrieving next available story from Pivotal Tracker...
Story: Keep a mongoose
Enter branch name: ^C
Aborted story branch.
Traceback (most recent call last):
  File "<string>", line 16, in <module>
  File "/private/tmp/continuity-1DRzO2/continuity-0.9.6/build/continuity/out00-PYZ.pyz/continuity.cli", line 134, in main
  File "/private/tmp/continuity-1DRzO2/continuity-0.9.6/build/continuity/out00-PYZ.pyz/continuity.cli.commons", line 90, in __call__
  File "/private/tmp/continuity-1DRzO2/continuity-0.9.6/build/continuity/out00-PYZ.pyz/continuity.cli.pt", line 266, in exit
  File "/private/tmp/continuity-1DRzO2/continuity-0.9.6/build/continuity/out00-PYZ.pyz/async", line 21, in thread_interrupt_handler
KeyboardInterrupt
```
