### PR TITLE
git-issue --comments UnicodeEncodeError

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+Version 0.9.10
+~~~~~~~~~~~~~~
+
+* Fixed 'issues --comments' output.
+
 Version 0.9.9
 ~~~~~~~~~~~~~
 
@@ -14,7 +19,7 @@ Version 0.9.8
 Version 0.9.7
 ~~~~~~~~~~~~~
 
-* Fixed JIRA `issues --myissues` query.
+* Fixed JIRA 'issues --myissues' query.
 * Improved handling for unicode strings.
 * Update installation dependencies.
 

--- a/continuity/__init__.py
+++ b/continuity/__init__.py
@@ -11,4 +11,4 @@
 
 __author__ = "Jonathan Zempel"
 __license__ = "BSD"
-__version__ = "0.9.9"
+__version__ = "0.9.10"

--- a/continuity/cli/utils.py
+++ b/continuity/cli/utils.py
@@ -196,6 +196,9 @@ def to_ascii(string):
     :param string: The string to convert.
     """
     if not isinstance(string, unicode):
-        string = unicode(str(string), "utf-8")
+        if isinstance(string, str):
+            string = unicode(string, "utf-8")
+        else:
+            string = unicode(string)
 
     return normalize("NFKD", string).encode("ascii", "ignore")


### PR DESCRIPTION
Fix for #42 introduced this regression:

```
Traceback (most recent call last):
  File "<string>", line 16, in <module>
  File "/private/tmp/continuity-pForSO/continuity-0.9.9/build/continuity/out00-PYZ.pyz/continuity.cli", line 134, in main
  File "/private/tmp/continuity-pForSO/continuity-0.9.9/build/continuity/out00-PYZ.pyz/continuity.cli.commons", line 85, in __call__
  File "/private/tmp/continuity-pForSO/continuity-0.9.9/build/continuity/out00-PYZ.pyz/continuity.cli.github", line 136, in execute
  File "/private/tmp/continuity-pForSO/continuity-0.9.9/build/continuity/out00-PYZ.pyz/continuity.cli.utils", line 149, in puts
  File "/private/tmp/continuity-pForSO/continuity-0.9.9/build/continuity/out00-PYZ.pyz/continuity.cli.utils", line 199, in to_ascii
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2014' in position 821: ordinal not in range(128)
```