### PR TITLE
Rollback git repository override

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Version 0.9.10
 ~~~~~~~~~~~~~~
 
 * Fixed 'issues --comments' output.
+* Remove git service repo override.
 
 Version 0.9.9
 ~~~~~~~~~~~~~

--- a/continuity/services/git.py
+++ b/continuity/services/git.py
@@ -14,7 +14,7 @@ from .commons import ServiceException
 from git.exc import GitCommandError, InvalidGitRepositoryError, NoSuchPathError
 from git.repo.base import Repo
 from os import environ, utime
-from os.path import basename, exists, expanduser, join
+from os.path import basename, exists, join
 from sys import exc_info
 import re
 
@@ -33,29 +33,6 @@ class GitException(ServiceException):
     def __init__(self, message, status=None):
         super(GitException, self).__init__(message)
         self.status = status
-
-
-class GitRepository(Repo):
-    """Git repository.
-    """
-
-    config_level = ("system", "user", "global", "repository")
-
-    def _get_config_path(self, config_level):
-        """Override to support the "user" configuration level until
-           `https://github.com/gitpython-developers/GitPython/issues/160` is
-           fixed.
-
-        :param config_level: The configuration level to get a path for.
-        """
-        if config_level == "user":
-            config_home = environ.get("XDG_CONFIG_HOME") or join(environ.get(
-                "HOME", '~'), ".config")
-            ret_val = expanduser(join(config_home, "git", "config"))
-        else:
-            ret_val = super(GitRepository, self)._get_config_path(config_level)
-
-        return ret_val
 
 
 class GitService(object):
@@ -84,7 +61,7 @@ class GitService(object):
                 self.execute("add", basename(name))
                 self.execute("commit", "-m", "Initial commit")
             else:
-                self.repo = GitRepository(path)
+                self.repo = Repo(path)
 
             if origin:
                 try:

--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,12 @@ import continuity
 
 install_requires = [
     "clint == 0.4.1",
-    "GitPython == 0.3.2.1",
+    "GitPython == 0.3.6",
     "Jinja2 == 2.7.3",
     "py-getch == 0.0.1",
     "python-dateutil < 2.0",
     "requests == 2.5.0",
-    "Sphinx == 1.2.3"
+    "Sphinx == 1.3.1"
 ]
 
 if "develop" in argv:


### PR DESCRIPTION
[`GitRepository`](https://github.com/jzempel/continuity/blob/master/continuity/services/git.py#L38) is no longer necessary now that gitpython-developers/GitPython#160 is fixed in [v0.3.6](https://github.com/gitpython-developers/GitPython/releases/tag/0.3.6) of GitPython.