### PR TITLE
Explicit "six" dependency

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+Version 0.10.1
+~~~~~~~~~~~~~~
+
+* Added explicit 'six' installation dependency.
+
 Version 0.10.0
 ~~~~~~~~~~~~~~
 

--- a/continuity/__init__.py
+++ b/continuity/__init__.py
@@ -11,4 +11,4 @@
 
 __author__ = "Jonathan Zempel"
 __license__ = "BSD"
-__version__ = "0.10.0"
+__version__ = "0.10.1"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ install_requires = [
     "py-getch == 1.0.1",
     "python-dateutil == 2.4.2",
     "requests == 2.9.1",
-    "Sphinx == 1.3.4"
+    "Sphinx == 1.3.4",
+    "six == 1.10.0"
 ]
 
 if "develop" in argv:


### PR DESCRIPTION
To prevent the following error on brew install (OSX El Capitan):
`Installed distribution six 1.4.1 conflicts with requirement six>=1.5`