### PR TITLE
Support github.token in gitconfig

### DIFF
--- a/continuity/cli/commons.py
+++ b/continuity/cli/commons.py
@@ -31,8 +31,8 @@ MESSAGES = {
     "git_branch": "Enter branch name",
     "github_2fa_code": "GitHub two-factor authentication code",
     "github_exclusive": "Exclude issues not assigned to you?",
-    "github_oauth_token": "GitHub OAuth token",
     "github_password": "GitHub password",
+    "github_token": "GitHub OAuth token",
     "github_user": "GitHub user",
     "jira_password": "JIRA password",
     "jira_project_key": "JIRA project key",
@@ -182,7 +182,7 @@ class GitHubCommand(GitCommand):
     def github(self):
         """GitHub accessor.
         """
-        token = self.get_value("github", "oauth-token")
+        token = self.get_value("github", "token")
 
         return GitHubService(self.git, token)
 
@@ -355,7 +355,7 @@ class InitCommand(GitCommand):
         self.git.set_configuration("alias", **self.aliases)
 
         if self.pivotal:
-            github = GitHubService(self.git, self.github["oauth-token"])
+            github = GitHubService(self.git, self.github["token"])
             hooks = github.get_hooks()
 
             if hooks is not None:
@@ -449,10 +449,10 @@ class InitCommand(GitCommand):
         """Initialize github data.
         """
         configuration = self.git.get_configuration("github")
-        token = configuration.get("oauth-token")
+        token = configuration.get("token")
 
         if token and not self.namespace.new:
-            token = prompt(MESSAGES["github_oauth_token"], token)
+            token = prompt(MESSAGES["github_token"], token)
         else:
             user = prompt(MESSAGES["github_user"], configuration.get("user"))
             password = prompt(MESSAGES["github_password"], echo=False)
@@ -470,7 +470,7 @@ class InitCommand(GitCommand):
             if not token:
                 exit("Invalid GitHub credentials.")
 
-        return {"oauth-token": token}
+        return {"token": token}
 
     def initialize_jira(self):
         """Initialize jira data.

--- a/continuity/tests/__init__.py
+++ b/continuity/tests/__init__.py
@@ -204,7 +204,7 @@ class ContinuityTestCase(TestCase):
         ]
         self.git.remove_configuration("alias", None, *options)
         self.git.remove_configuration("continuity")
-        self.git.remove_configuration("github", None, "oauth-token")
+        self.git.remove_configuration("github", None, "token")
         options = ["api-token", "email", "owner-id", "project-id"]
         self.git.remove_configuration("pivotal", None, *options)
         self.command_count = 0

--- a/continuity/tests/commons.py
+++ b/continuity/tests/commons.py
@@ -24,7 +24,7 @@ class InitCommandTestCase(ContinuityTestCase):
         self.assert_equal(configuration["tracker"], "github")
         self.assert_false(configuration["exclusive"])
         configuration = self.git.get_configuration("github")
-        self.assert_in("oauth-token", configuration)
+        self.assert_in("token", configuration)
         configuration = self.git.get_configuration("alias")
         self.assert_in("issue", configuration)
         self.assert_in("issues", configuration)
@@ -70,11 +70,11 @@ class InitCommandTestCase(ContinuityTestCase):
         """
         self.command("init", continuity_tracker='G')
         configuration = self.git.get_configuration("github")
-        token = configuration["oauth-token"]
+        token = configuration["token"]
         self.command("init --new", continuity_tracker='G',
-                github_oauth_token=None)
+                github_token=None)
         configuration = self.git.get_configuration("github")
-        self.assert_equal(token, configuration["oauth-token"])
+        self.assert_equal(token, configuration["token"])
 
     def test_refresh_pivotal(self):
         """init: refresh Pivotal Tracker configuration.

--- a/continuity/tests/github.py
+++ b/continuity/tests/github.py
@@ -27,7 +27,7 @@ class GitHubCommandTestCase(ContinuityTestCase):
                 "continuity_integration_branch"]
         }
         self.git.set_configuration("continuity", **continuity)
-        github = {"oauth-token": self.github.token}
+        github = {"token": self.github.token}
         self.git.set_configuration("github", **github)
 
 


### PR DESCRIPTION
Along with `github.oauth-token`, per https://github.com/blog/180-local-github-config
